### PR TITLE
Add simple Kafka sync scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Neo4j rbac 权限隔离。
 
 按以上思路落地，可在保持系统简单可维护的同时，获得近实时（秒级）的一致数据视图，支撑事务处理与图分析两类负载。祝你架构顺利！
 
+8  示例代码
+仓库新增 `sync_service.py` 与 `sync_service_mysql.py` 两个脚本，用于演示事件消费写入。
+
+- `sync_service.py` 从 Kafka 主题 `mysql.customer.v1` 读取事件，利用 Neo4j Bolt 驱动按 `eventId` 幂等 `MERGE` 节点；
+- `sync_service_mysql.py` 监听 `neo4j.customer.v1`，将图更新以 Upsert 方式写回 MySQL。
+
+脚本示例化了循环抑制、去重与基本 Upsert 逻辑，方便在本地小规模试验。
+
 
 
 

--- a/sync_service.py
+++ b/sync_service.py
@@ -1,0 +1,85 @@
+import json
+from confluent_kafka import Consumer
+from neo4j import GraphDatabase
+
+
+class SyncService:
+    """Consume change events from Kafka and upsert them into Neo4j.
+
+    Events are expected to be JSON with at least:
+      - eventId: unique identifier for idempotency
+      - payload: dictionary describing node properties
+      - source: origin system (e.g. 'MYSQL', 'NEO4J')
+      - label: Neo4j node label
+    """
+
+    def __init__(self, kafka_config, neo4j_uri, neo4j_auth, topic, source_label="MYSQL"):
+        self.consumer = Consumer(kafka_config)
+        self.consumer.subscribe([topic])
+        self.driver = GraphDatabase.driver(neo4j_uri, auth=neo4j_auth)
+        self.source_label = source_label
+        self.seen_event_ids = set()
+
+    def close(self):
+        self.consumer.close()
+        self.driver.close()
+
+    def handle_event(self, event):
+        if not event:
+            return
+        try:
+            data = json.loads(event.value())
+        except json.JSONDecodeError:
+            print("invalid event", event.value())
+            return
+
+        event_id = data.get("eventId")
+        if event_id in self.seen_event_ids:
+            # deduplicate
+            return
+        self.seen_event_ids.add(event_id)
+
+        if data.get("source") == self.source_label:
+            # drop events originating from the same system to avoid loop
+            return
+
+        label = data.get("label", "Entity")
+        props = data.get("payload", {})
+        key = props.get("id")
+        if key is None:
+            print("missing id in payload")
+            return
+
+        with self.driver.session() as session:
+            session.execute_write(self._merge_node, label, key, props)
+
+    @staticmethod
+    def _merge_node(tx, label, key, props):
+        prop_keys = ", ".join(f"{k}: ${k}" for k in props.keys())
+        query = f"MERGE (n:{label} {{id: $id}}) SET n += {{{prop_keys}}}"
+        tx.run(query, **props)
+
+    def start(self):
+        try:
+            while True:
+                msg = self.consumer.poll(1.0)
+                if msg is None:
+                    continue
+                if msg.error():
+                    print("consumer error", msg.error())
+                    continue
+                self.handle_event(msg)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.close()
+
+
+if __name__ == "__main__":
+    kafka_conf = {
+        "bootstrap.servers": "localhost:9092",
+        "group.id": "sync-service",
+        "auto.offset.reset": "earliest",
+    }
+    service = SyncService(kafka_conf, "bolt://localhost:7687", ("neo4j", "test"), "mysql.customer.v1")
+    service.start()

--- a/sync_service_mysql.py
+++ b/sync_service_mysql.py
@@ -1,0 +1,87 @@
+import json
+from confluent_kafka import Consumer
+import mysql.connector
+
+
+class SyncServiceMySQL:
+    """Consume Neo4j change events and write them into MySQL tables.
+
+    Events should have:
+      - eventId
+      - payload: dict with columns
+      - source: origin system
+      - table: destination table name
+    """
+
+    def __init__(self, kafka_config, mysql_config, topic, source_label="NEO4J"):
+        self.consumer = Consumer(kafka_config)
+        self.consumer.subscribe([topic])
+        self.conn = mysql.connector.connect(**mysql_config)
+        self.source_label = source_label
+        self.seen_event_ids = set()
+
+    def close(self):
+        self.consumer.close()
+        self.conn.close()
+
+    def handle_event(self, event):
+        if not event:
+            return
+        try:
+            data = json.loads(event.value())
+        except json.JSONDecodeError:
+            print("invalid event", event.value())
+            return
+
+        event_id = data.get("eventId")
+        if event_id in self.seen_event_ids:
+            return
+        self.seen_event_ids.add(event_id)
+
+        if data.get("source") == self.source_label:
+            return
+
+        table = data.get("table")
+        payload = data.get("payload", {})
+        if not table or "id" not in payload:
+            print("missing table or id")
+            return
+
+        columns = ", ".join(payload.keys())
+        placeholders = ", ".join(["%s"] * len(payload))
+        updates = ", ".join(f"{c}=VALUES({c})" for c in payload.keys())
+        sql = f"INSERT INTO {table} ({columns}) VALUES ({placeholders}) ON DUPLICATE KEY UPDATE {updates}"
+        with self.conn.cursor() as cur:
+            cur.execute(sql, list(payload.values()))
+        self.conn.commit()
+
+    def start(self):
+        try:
+            while True:
+                msg = self.consumer.poll(1.0)
+                if msg is None:
+                    continue
+                if msg.error():
+                    print("consumer error", msg.error())
+                    continue
+                self.handle_event(msg)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.close()
+
+
+if __name__ == "__main__":
+    kafka_conf = {
+        "bootstrap.servers": "localhost:9092",
+        "group.id": "sync-service-mysql",
+        "auto.offset.reset": "earliest",
+    }
+    mysql_conf = {
+        "host": "localhost",
+        "user": "root",
+        "password": "password",
+        "database": "testdb",
+    }
+    service = SyncServiceMySQL(kafka_conf, mysql_conf, "neo4j.customer.v1")
+    service.start()


### PR DESCRIPTION
## Summary
- add a Python service to consume MySQL events and upsert into Neo4j
- add a companion service syncing Neo4j events back to MySQL
- document the example scripts

## Testing
- `pip install confluent-kafka neo4j mysql-connector-python`


------
https://chatgpt.com/codex/tasks/task_e_688442fe90508326a2c9acdb43fa9260