### PR TITLE
Add schema version routing and relationship handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ Neo4j rbac 权限隔离。
 按以上思路落地，可在保持系统简单可维护的同时，获得近实时（秒级）的一致数据视图，支撑事务处理与图分析两类负载。祝你架构顺利！
 
 8  示例代码
-仓库新增 `sync_service.py` 与 `sync_service_mysql.py` 两个脚本，用于演示事件消费写入。
+仓库包含 `sync_service.py` 与 `sync_service_mysql.py` 两个脚本，用于演示事件消费与写入。
 
-- `sync_service.py` 从 Kafka 主题 `mysql.customer.v1` 读取事件，利用 Neo4j Bolt 驱动按 `eventId` 幂等 `MERGE` 节点；
-- `sync_service_mysql.py` 监听 `neo4j.customer.v1`，将图更新以 Upsert 方式写回 MySQL。
+- `sync_service.py` 从 Kafka 主题 `mysql.customer.v1` 读取事件，根据 `schemaVersion` 路由：v1 进行节点 `MERGE`，v2 写入关系；
+- `sync_service_mysql.py` 监听 `neo4j.customer.v1`，同样按 `schemaVersion` 路由，将图更新 Upsert 回 MySQL。
 
-脚本示例化了循环抑制、去重与基本 Upsert 逻辑，方便在本地小规模试验。
+事件依赖全局唯一 `id` 属性，并携带 `schemaVersion` 便于演进。脚本示例化了循环抑制、去重与基本 Upsert 逻辑，适合本地试验。
 
 
 


### PR DESCRIPTION
## Summary
- support `schemaVersion` routing in both sync services
- add relationship merge example for Neo4j updates
- mention version routing and global IDs in README

## Testing
- `python -m py_compile sync_service.py sync_service_mysql.py`

------
https://chatgpt.com/codex/tasks/task_e_68844457be5c8326b52b4c0f243daa76